### PR TITLE
Visitor can choose category

### DIFF
--- a/cypress/fixtures/flashcards.json
+++ b/cypress/fixtures/flashcards.json
@@ -68,7 +68,7 @@
   "meta": {
     "currentPage": 1,
     "nextPage": 2,
-    "prevPage": "nil", 
+    "prevPage": null, 
     "totalPages": 2, 
     "totalCount": 2
   }

--- a/cypress/fixtures/flashcards_ruby_1.json
+++ b/cypress/fixtures/flashcards_ruby_1.json
@@ -1,0 +1,75 @@
+{
+  "decks": [
+    {
+      "category": "Ruby",
+      "flashcards": [
+        {
+          "id": 1,
+          "question": "What do you call a method with exclamation point? 2 answers.",
+          "answer": "Bang version of the method or unsafe method."
+        },
+      
+        {
+          "id": 2,
+          "question": "What is difference between gsub and sub?",
+          "answer": "gsub is 'general' sub and replaces all instances. sub only replaces first instance."
+        },
+      
+        {
+          "id": 3,
+          "question": "How do you use nil?",
+          "answer": "puts 'Couldn't find answer' if [1, 2, 3].index(42).nil?"
+        },
+      
+        {
+          "id": 4,
+          "question": "Object that is a block of code that can be bound to a set of local variables",
+          "answer": "Proc"
+        },
+      
+        {
+          "id": 5,
+          "question": "Turn 'Tom', 'Bill', 'Jerry' into the string 'Tom, Bill, Jerry'",
+          "answer": "Use array.join(', ')"
+        },
+      
+        {
+          "id": 6,
+          "question": "What is a function declaration compared to a function expression?",
+          "answer": "declaration: function myFunc(){ ... }, expression: var myFunc = function() { ... }"
+        },
+      
+        {
+          "id": 7,
+          "question": "How could you get today’s day (e.g. “Monday”) from the date object?",
+          "answer": "You need to make an array with Sunday at 0 index and Saturday at 7 index. Then use getDay() and find the day using your array."
+        },
+      
+        {
+          "id": 8,
+          "question": "What does a for ... in loop do and what does it look like?",
+          "answer": "It iterates over the enumerable properties in an object like this: for (var prop in obj) {// optionally, find only properties of this object, not the objects from which it inherits if (obj.hasOwnProperty(prop) { // do something"
+        },
+      
+        {
+          "id": 9,
+          "question": "How do you access the function you are in (e.g. for a factorial)?",
+          "answer": "Use the name of the function. Arguments.caller is deprecated."
+        },
+      
+        {
+          "id": 10,
+          "question": "var s = String; typeof s will be what?",
+          "answer": "'function'"
+        }
+      ]
+    }  
+  ],
+  "meta": {
+    "currentPage": 2,
+    "nextPage": null,
+    "prevPage": 1, 
+    "totalPages": 2, 
+    "totalCount": 2
+  }
+}

--- a/cypress/fixtures/flashcards_ruby_1.json
+++ b/cypress/fixtures/flashcards_ruby_1.json
@@ -66,7 +66,7 @@
     }  
   ],
   "meta": {
-    "currentPage": 2,
+    "currentPage": 1,
     "nextPage": null,
     "prevPage": 1, 
     "totalPages": 2, 

--- a/cypress/fixtures/flashcards_second_page.json
+++ b/cypress/fixtures/flashcards_second_page.json
@@ -67,7 +67,7 @@
   ],
   "meta": {
     "currentPage": 2,
-    "nextPage": "nil",
+    "nextPage": null,
     "prevPage": 1, 
     "totalPages": 2, 
     "totalCount": 2

--- a/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
+++ b/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
@@ -4,23 +4,64 @@ describe('Visitor can choose decks of a specific category', () => {
     cy.route({
       method: 'GET',
       url: 'http://localhost:3000/api/decks',
+      response: 'fixture:flashcards_second_page.json',
+      status: 200
+    });
+
+    cy.route({
+      method: 'PUT',
+      url: 'http://localhost:3000/api/flashcards/**',
+      response: 'fixture:successful_update_flashcard_status.json',
+      status: 200
+    });
+
+    cy.route({
+      method: 'GET',
+      url: 'http://localhost:3000/api/decks',
       response: 'fixture:flashcards.json',
       status: 200
     });
     cy.visit('http://localhost:3001');
   });
 
-  it('Displays option buttons for different categories', async () => {
-    cy.get('#category-buttons').within(() => {
-      cy.get('#ruby').contains('Ruby');
-      cy.get('#javascript').contains('JavaScript');
-      cy.get('#commands').contains('Git Commands');
+  describe('Categories', () => {
+    it('can be chosen by clicking category buttons', () => {
+      cy.get('#category-buttons').within(() => {
+        cy.get('#ruby').contains('Ruby');
+        cy.get('#javascript').contains('JavaScript');
+        cy.get('#commands').contains('Git Commands');
+      });
     });
   });
 
-  // it('Displays option buttons for different categories', () => {
-  //   cy.get('#ruby').click(
-  //     cy.get('#ruby').click(
-  //   )
+  // describe("Visitor can get decks of 'Ruby' category only", () => {
+  //   it('successfully', () => {
+  //     cy.get('#ruby').click();
+
+  //     for(let n = 0; n < 10; n ++){
+  //       cy.get('#green').click()
+  //       cy.wait(500)
+  //     }
+
+  //     cy.get('#get-new-deck').click();
+  //     cy.get('#question_1').contains('What do you call a method with exclamation point? 2 answers.');
+  //     cy.get('#answer_1').contains('Bang version of the method or unsafe method');
+  //   })
   // });
+
+  describe("Visitor can get decks of 'Ruby' category first and then change to JavaScript", () => {
+    it('successfully', () => {
+      cy.get('#ruby').click();
+
+      for(let n = 0; n < 10; n ++){
+        cy.get('#red').click()
+        cy.wait(500)
+      }
+
+      cy.get('#javascript').click();
+      cy.get('#get-new-deck').click();
+      cy.get('#question_1').contains('How can you include an external javascript file?');
+      cy.get('#answer_1').contains("/script src='myfile.js'/");
+    })
+  });
 })

--- a/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
+++ b/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
@@ -1,9 +1,24 @@
 describe('Visitor can choose decks of a specific category', () => {
   beforeEach(() => {
     cy.server();
+
     cy.route({
       method: 'GET',
       url: 'http://localhost:3000/api/decks',
+      response: 'fixture:flashcards.json',
+      status: 200
+    });
+
+    cy.route({
+      method: 'GET',
+      url: 'http://localhost:3000/api/decks/?category**',
+      response: 'fixture:flashcards_ruby_1.json',
+      status: 200
+    })
+
+    cy.route({
+      method: 'GET',
+      url: 'http://localhost:3000/api/decks/?page**',
       response: 'fixture:flashcards_second_page.json',
       status: 200
     });
@@ -15,12 +30,7 @@ describe('Visitor can choose decks of a specific category', () => {
       status: 200
     });
 
-    cy.route({
-      method: 'GET',
-      url: 'http://localhost:3000/api/decks',
-      response: 'fixture:flashcards.json',
-      status: 200
-    });
+    
     cy.visit('http://localhost:3001');
   });
 
@@ -34,34 +44,19 @@ describe('Visitor can choose decks of a specific category', () => {
     });
   });
 
-  // describe("Visitor can get decks of 'Ruby' category only", () => {
-  //   it('successfully', () => {
-  //     cy.get('#ruby').click();
-
-  //     for(let n = 0; n < 10; n ++){
-  //       cy.get('#green').click()
-  //       cy.wait(500)
-  //     }
-
-  //     cy.get('#get-new-deck').click();
-  //     cy.get('#question_1').contains('What do you call a method with exclamation point? 2 answers.');
-  //     cy.get('#answer_1').contains('Bang version of the method or unsafe method');
-  //   })
-  // });
-
-  describe("Visitor can get decks of 'Ruby' category first and then change to JavaScript", () => {
+  describe("Visitor can get decks of 'Ruby' category only", () => {
     it('successfully', () => {
       cy.get('#ruby').click();
 
       for(let n = 0; n < 10; n ++){
-        cy.get('#red').click()
+        cy.get('#green').click()
         cy.wait(500)
       }
 
-      cy.get('#javascript').click();
       cy.get('#get-new-deck').click();
-      cy.get('#question_1').contains('How can you include an external javascript file?');
-      cy.get('#answer_1').contains("/script src='myfile.js'/");
+      
+      cy.get('#question_1').contains('Quotes used with string interpolation');
+      cy.get('#answer_1').contains("# double quote");
     })
   });
 })

--- a/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
+++ b/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
@@ -1,0 +1,26 @@
+describe('Visitor can choose decks of a specific category', () => {
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: 'GET',
+      url: 'http://localhost:3000/api/decks',
+      response: 'fixture:flashcards.json',
+      status: 200
+    });
+    cy.visit('http://localhost:3001');
+  });
+
+  it('Displays option buttons for different categories', async () => {
+    cy.get('.category-buttons').within(() => {
+      cy.get('#ruby').contains('Ruby');
+      cy.get('#javascript').contains('JavaScript');
+      cy.get('#commands').contains('Git Commands');
+    });
+  });
+
+  // it('Displays option buttons for different categories', () => {
+  //   cy.get('#category').within(
+  //     cy.get('#ruby').click(
+  //   )
+  // });
+})

--- a/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
+++ b/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
@@ -19,7 +19,7 @@ describe('Visitor can choose decks of a specific category', () => {
   });
 
   // it('Displays option buttons for different categories', () => {
-  //   cy.get('#category').within(
+  //   cy.get('#ruby').click(
   //     cy.get('#ruby').click(
   //   )
   // });

--- a/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
+++ b/cypress/integration/visitorCanChooseDecksOfSpecificCategory.spec.js
@@ -11,7 +11,7 @@ describe('Visitor can choose decks of a specific category', () => {
   });
 
   it('Displays option buttons for different categories', async () => {
-    cy.get('.category-buttons').within(() => {
+    cy.get('#category-buttons').within(() => {
       cy.get('#ruby').contains('Ruby');
       cy.get('#javascript').contains('JavaScript');
       cy.get('#commands').contains('Git Commands');

--- a/src/components/CategoryButtons.js
+++ b/src/components/CategoryButtons.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Grid, Button, Sticky } from 'semantic-ui-react';
+
+const CategoryButtons = (props) => {
+  // let getCategoryDeck = props.category;
+  return (
+    <div id='category-buttons'>
+      <Sticky>
+        <Grid id='footer' centered columns={8}>
+          <Grid.Column verticalAlign='middle' width={8}>
+            <Button
+              onClick={props.getCategoryDeck}
+              id='ruby'
+            >
+              Ruby
+            </Button>
+            <Button
+              onClick={props.getCategoryDeck}
+              id='javascript'
+            >
+              JavaScript
+            </Button>
+            <Button
+              onClick={props.getCategoryDeck}
+              id='commands'
+            >
+              Git Commands
+            </Button>
+          </Grid.Column>
+        </Grid>
+      </Sticky>
+    </div>
+  )
+}
+
+export default CategoryButtons; 

--- a/src/components/CategoryButtons.js
+++ b/src/components/CategoryButtons.js
@@ -6,26 +6,26 @@ const CategoryButtons = (props) => {
   return (
     <div id='category-buttons'>
       <Sticky>
-        <Grid id='footer' centered columns={8}>
-          <Grid.Column verticalAlign='middle' width={8}>
-            <Button 
-              onClick={props.getCategoryDeck}
-              id='ruby'
-            >
-              Ruby
-            </Button>
-            <Button            
-              onClick={props.getCategoryDeck}
-              id='javascript'
-            >
-              JavaScript
-            </Button>
-            <Button
-             onClick={props.getCategoryDeck}
-              id='commands'
-            >
-              Git Commands
-            </Button>
+        <Grid id='footer' centered columns={20}>
+          <Grid.Column verticalAlign='middle' width={20}>
+                <Button style={{ width: 300, height: 40 }}
+                  onClick={props.getCategoryDeck}
+                  id='ruby'
+                >
+                  Ruby
+              </Button>
+                <Button style={{ width: 300, height: 40 }}
+                  onClick={props.getCategoryDeck}
+                  id='javascript'
+                >
+                  JavaScript
+              </Button>
+                <Button style={{ width: 300, height: 40 }}
+                  onClick={props.getCategoryDeck}
+                  id='commands'
+                >
+                  Git Commands
+              </Button>
           </Grid.Column>
         </Grid>
       </Sticky>

--- a/src/components/CategoryButtons.js
+++ b/src/components/CategoryButtons.js
@@ -2,26 +2,26 @@ import React from 'react';
 import { Grid, Button, Sticky } from 'semantic-ui-react';
 
 const CategoryButtons = (props) => {
-  // let getCategoryDeck = props.category;
+
   return (
     <div id='category-buttons'>
       <Sticky>
         <Grid id='footer' centered columns={8}>
           <Grid.Column verticalAlign='middle' width={8}>
-            <Button
+            <Button 
               onClick={props.getCategoryDeck}
               id='ruby'
             >
               Ruby
             </Button>
-            <Button
+            <Button            
               onClick={props.getCategoryDeck}
               id='javascript'
             >
               JavaScript
             </Button>
             <Button
-              onClick={props.getCategoryDeck}
+             onClick={props.getCategoryDeck}
               id='commands'
             >
               Git Commands

--- a/src/components/PresentFlashcard.js
+++ b/src/components/PresentFlashcard.js
@@ -25,7 +25,7 @@ export class PresentFlashcard extends Component {
 
   getNewDeck = async () => {
     let page;
-    let response; 
+    let response;
 
     if (this.state.nextDeckPage === null) {
       page = 1
@@ -33,10 +33,10 @@ export class PresentFlashcard extends Component {
       page = this.state.nextDeckPage
     }
 
-    if(this.state.onlySpecificTypeOfDeck === true) {
-    response = await axios.get(`http://localhost:3000/api/decks/?page=${page}&category=${this.state.deckCategory}`);
+    if (this.state.onlySpecificTypeOfDeck === true) {
+      response = await axios.get(`http://localhost:3000/api/decks/?page=${page}&category=${this.state.deckCategory}`);
     } else {
-    response = await axios.get(`http://localhost:3000/api/decks/?page=${page}`);
+      response = await axios.get(`http://localhost:3000/api/decks/?page=${page}`);
     }
 
     this.setState({
@@ -57,7 +57,7 @@ export class PresentFlashcard extends Component {
 
   getCategoryDeck = async (event) => {
     let category = event.target.id
-    
+
     const response = await axios.get(`http://localhost:3000/api/decks/?category=${category}`);
 
     this.setState({
@@ -93,9 +93,9 @@ export class PresentFlashcard extends Component {
 
     if (flashcards.length >= 1 && this.state.renderDeckOption !== true) {
       flashcardDisplay = (
-        <Flashcard 
-          flashcard={flashcards[this.state.activeFlashcard]} 
-          key={flashcards[this.state.activeFlashcard].id} 
+        <Flashcard
+          flashcard={flashcards[this.state.activeFlashcard]}
+          key={flashcards[this.state.activeFlashcard].id}
           updateStatus={this.updateStatus}
           currentDeckCategory={this.state.deckCategory}
         />
@@ -105,16 +105,23 @@ export class PresentFlashcard extends Component {
     if (this.state.renderDeckOption === true) {
       chooseDeckOption = (
         <>
-          <Button onClick={() => this.repeatCurrentDeck()} id="repeat-deck">
-            Repeat
+          <Container>
+            <Button onClick={() => this.repeatCurrentDeck()}
+              id="repeat-deck"
+              basic color='red'
+            >
+              Repeat
           </Button>
-          <Button onClick={() => this.getNewDeck()} id="get-new-deck">
-            New Deck
+            <Button onClick={() => this.getNewDeck()}
+              id="get-new-deck"
+              basic color='green'>
+              New Deck
           </Button>
+          </Container>
         </>
       )
     };
-    
+
     return (
       <>
         <Container>

--- a/src/components/PresentFlashcard.js
+++ b/src/components/PresentFlashcard.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import axios from "axios";
 import { updateFlashcardStatus } from "../modules/updateFlashcardStatus";
 import Flashcard from "./Flashcard";
-import { Container, Button } from 'semantic-ui-react';
+import { Container, Button, Grid } from 'semantic-ui-react';
 import CategoryButtons from './CategoryButtons';
 
 export class PresentFlashcard extends Component {
@@ -105,18 +105,24 @@ export class PresentFlashcard extends Component {
     if (this.state.renderDeckOption === true) {
       chooseDeckOption = (
         <>
-          <Container>
-            <Button onClick={() => this.repeatCurrentDeck()}
-              id="repeat-deck"
-              basic color='red'
-            >
-              Repeat
-          </Button>
-            <Button onClick={() => this.getNewDeck()}
-              id="get-new-deck"
-              basic color='green'>
-              New Deck
-          </Button>
+        <Container>
+            <Grid id='repeat' centered columns={20}>
+              <Grid.Column verticalAlign='middle' width={40} >
+                  <Button onClick={() => this.repeatCurrentDeck()} 
+                    style={{ width: 200, height: 40 }}
+                    id="repeat-deck"
+                    basic color='red'
+                  >
+                    Repeat
+                </Button>
+                  <Button onClick={() => this.getNewDeck()} 
+                    style={{ width: 200, height: 40 }}
+                    id="get-new-deck"
+                    basic color='green'>
+                    New Deck
+                </Button>
+              </Grid.Column>
+            </Grid>
           </Container>
         </>
       )

--- a/src/components/PresentFlashcard.js
+++ b/src/components/PresentFlashcard.js
@@ -3,6 +3,7 @@ import axios from "axios";
 import { updateFlashcardStatus } from "../modules/updateFlashcardStatus";
 import Flashcard from "./Flashcard";
 import { Container, Button } from 'semantic-ui-react';
+import CategoryButtons from './CategoryButtons';
 
 export class PresentFlashcard extends Component {
   state = {
@@ -121,17 +122,8 @@ export class PresentFlashcard extends Component {
           {chooseDeckOption}
         </Container>
 
-        <div className='category-buttons'>
-          <Button onClick={(e) => this.getCategoryDeck(e)} id="ruby">
-            Ruby
-          </Button>
-          <Button onClick={(e) => this.getCategoryDeck(e)} id="javascript"> 
-            JavaScript
-          </Button>
-          <Button onClick={(e) => this.getCategoryDeck(e)} id="commands">
-            Git Commands
-          </Button>
-        </div>
+        <CategoryButtons
+          getCategoryDeck={this.state.getCategoryDeck} />
       </>
     )
   }

--- a/src/components/PresentFlashcard.js
+++ b/src/components/PresentFlashcard.js
@@ -8,42 +8,66 @@ export class PresentFlashcard extends Component {
   state = {
     flashcards: [],
     activeFlashcard: 0,
-    nextDeckPage: "nil"
+    nextDeckPage: null,
+    deckCategory: '',
+    onlySpecificTypeOfDeck: false
   };
 
   async componentDidMount() {
     const response = await axios.get("http://localhost:3000/api/decks");
     this.setState({
       flashcards: response.data.decks[0].flashcards,
-      nextDeckPage: response.data.meta.nextPage
+      nextDeckPage: response.data.meta.nextPage,
+      deckCategory: response.data.decks[0].category
     });
   };
 
   getNewDeck = async () => {
     let page;
-    
-    if (this.state.nextDeckPage === "nil") {
+    let response; 
+
+    if (this.state.nextDeckPage === null) {
       page = 1
     } else {
       page = this.state.nextDeckPage
     }
 
-    const response = await axios.get(`http://localhost:3000/api/decks/?page=${page}`);
+    if(this.state.onlySpecificTypeOfDeck === true) {
+    response = await axios.get(`http://localhost:3000/api/decks/?page=${page}&category=${this.state.deckCategory}`);
+    } else {
+    response = await axios.get(`http://localhost:3000/api/decks/?page=${page}`);
+    }
 
     this.setState({
       flashcards: response.data.decks[0].flashcards,
       activeFlashcard: 0,
       nextDeckPage: response.data.meta.nextPage,
-      renderDeckOption: false
-    })
-  }
+      deckCategory: response.data.decks[0].category,
+      renderDeckOption: false,
+    });
+  };
 
   repeatCurrentDeck = () => {
     this.setState({
       activeFlashcard: 0,
       renderDeckOption: false
-    })
-  }
+    });
+  };
+
+  getCategoryDeck = async (event) => {
+    let category = event.target.id
+    
+    const response = await axios.get(`http://localhost:3000/api/decks/?category=${category}`);
+
+    this.setState({
+      flashcards: response.data.decks[0].flashcards,
+      activeFlashcard: 0,
+      nextDeckPage: response.data.meta.nextPage,
+      deckCategory: response.data.decks[0].category,
+      renderDeckOption: false,
+      onlySpecificTypeOfDeck: true
+    });
+  };
 
   updateStatus = (event) => {
     let status = event.target.id
@@ -57,7 +81,7 @@ export class PresentFlashcard extends Component {
         this.setState({
           activeFlashcard: this.state.activeFlashcard + 1
         })
-      }  
+      }
     })
   };
 
@@ -72,28 +96,43 @@ export class PresentFlashcard extends Component {
           flashcard={flashcards[this.state.activeFlashcard]} 
           key={flashcards[this.state.activeFlashcard].id} 
           updateStatus={this.updateStatus}
+          currentDeckCategory={this.state.deckCategory}
         />
       );
-    }
+    };
 
     if (this.state.renderDeckOption === true) {
       chooseDeckOption = (
         <>
           <Button onClick={() => this.repeatCurrentDeck()} id="repeat-deck">
             Repeat
-            </Button>
+          </Button>
           <Button onClick={() => this.getNewDeck()} id="get-new-deck">
             New Deck
           </Button>
         </>
       )
-    }
+    };
     
     return (
-      <Container>
-        {flashcardDisplay}
-        {chooseDeckOption}
-      </Container>
+      <>
+        <Container>
+          {flashcardDisplay}
+          {chooseDeckOption}
+        </Container>
+
+        <div className='category-buttons'>
+          <Button onClick={(e) => this.getCategoryDeck(e)} id="ruby">
+            Ruby
+          </Button>
+          <Button onClick={(e) => this.getCategoryDeck(e)} id="javascript"> 
+            JavaScript
+          </Button>
+          <Button onClick={(e) => this.getCategoryDeck(e)} id="commands">
+            Git Commands
+          </Button>
+        </div>
+      </>
     )
   }
 }

--- a/src/styling/customize.css
+++ b/src/styling/customize.css
@@ -21,3 +21,9 @@
   margin-left: 2rem;
   padding-top: 1rem;
 }
+
+#category-buttons{
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+}

--- a/src/styling/customize.css
+++ b/src/styling/customize.css
@@ -16,10 +16,20 @@
   color: rgb(125, 150, 37);
 }
 
-#header{
-  margin-top: 2px;
-  margin-left: 2rem;
-  padding-top: 1rem;
+/* Category buttons */
+#ruby {
+  background-color: #D1E687;
+  color: rgb(125, 150, 37);
+}
+
+#javascript{
+  background-color: #FFF389;
+  color: rgb(150, 136, 16);
+}
+
+#commands{
+  background-color: #FCA17E;
+  color: rgb(131, 75, 57);
 }
 
 #category-buttons{
@@ -27,3 +37,10 @@
   bottom: 0;
   width: 100%;
 }
+
+#header{
+  margin-top: 2px;
+  margin-left: 2rem;
+  padding-top: 1rem;
+}
+

--- a/src/styling/customize.css
+++ b/src/styling/customize.css
@@ -18,17 +18,23 @@
 
 /* Category buttons */
 #ruby {
-  background-color: #D1E687;
+  border: 2px solid rgb(201, 184, 29);
+  border-radius: 5px;
+  background-color: white;
+  color: rgb(201, 184, 29)
+}
+
+#javascript{  
+  border: 2px solid rgb(125, 150, 37);
+  border-radius: 5px;
+  background-color: white;
   color: rgb(125, 150, 37);
 }
 
-#javascript{
-  background-color: #FFF389;
-  color: rgb(150, 136, 16);
-}
-
 #commands{
-  background-color: #FCA17E;
+  border: 2px solid rgb(131, 75, 57);
+  border-radius: 5px;
+  background-color: white;
   color: rgb(131, 75, 57);
 }
 


### PR DESCRIPTION

<img width="912" alt="Screenshot 2019-09-11 at 10 41 54" src="https://user-images.githubusercontent.com/50490216/64681911-d53da480-d480-11e9-9802-fe83200d2fed.png">
### User Story

```
As a Visitor,
In order to practise a specific subject,
I would like to be able to only be provided by decks of a specific category.
```
### Feature description
Link to this [feature/chore in Pivotal Tracker][here](https://www.pivotaltracker.com/story/show/168404604).

### Description of PR
Provides with category buttons which makes possible a clear subject choices for the visitor available. Once a category has been chosen and clicked on, visitor will only see flashcards of that particular category.

### Screenshots
<img width="1006" alt="Screenshot 2019-09-10 at 20 33 59" src="https://user-images.githubusercontent.com/50490216/64640512-6c1b4a00-d40a-11e9-9ecb-09c6efbba5ca.png">


### What did we learn?
We learned how adjust the url and pagination in the spec & fixture files for testing properly
